### PR TITLE
Make docker-compose stack use Redis 5 by default

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - DEBUG=kuzzle:plugins
 
   redis:
-    image: redis:3.2
+    image: redis:5
 
   elasticsearch:
     image: kuzzleio/elasticsearch:5.6.10


### PR DESCRIPTION
## What does this PR do ?
Make the docker-compose stack used by setup.sh to use Redis 5 by default.

## How should this be manually tested?
Run the two docker-compose stack and check the image used by Redis container.